### PR TITLE
Allow brakepoints everywhere

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"debug.allowBreakpointsEverywhere": true
+}


### PR DESCRIPTION
Last thing to allow debugging was to allow brakepoints everywhere in vscode